### PR TITLE
Update based on Justin’s feedback

### DIFF
--- a/doc/_updateChild.md
+++ b/doc/_updateChild.md
@@ -1,10 +1,9 @@
 @function can-bind.prototype.updateChild updateChild
 @parent can-bind.prototype
 @description Set the child’s value as if the parent had changed.
+@hide
 @signature `binding.updateChild(newValue)`
 @param {*} newValue The child’s new value.
-
-@body
 
 This method sets the child’s value in a batch and increments the semaphore used
 to keep track of whether the parent should update when the child changes.

--- a/doc/_updateParent.md
+++ b/doc/_updateParent.md
@@ -1,10 +1,9 @@
 @function can-bind.prototype.updateParent updateParent
 @parent can-bind.prototype
 @description Set the parent’s value as if the child had changed.
+@hide
 @signature `binding.updateParent(newValue)`
 @param {*} newValue The parent’s new value.
-
-@body
 
 This method sets the parent’s value if it is not currently in an update cycle
 and the parent’s current value doesn’t already match the new value.

--- a/doc/parentValue.md
+++ b/doc/parentValue.md
@@ -3,9 +3,26 @@
 @description Returns the parent’s value.
 @signature `binding.parentValue`
 
-@body
+```js
+import Bind from "can-bind";
+import DefineMap from "can-define/map/map";
+import value from "can-value";
 
-This is the equivalent of doing:
+const parentMap = new DefineMap({parentProp: "parent value"});
+const parent = value.bind(parentMap, "parentProp");
+
+const childMap = new DefineMap({childProp: "child value"});
+const child = value.bind(childMap, "childProp");
+
+const binding = new Bind({
+  child: child,
+  parent: parent
+});
+
+binding.parentValue; // is "parent value"
+```
+
+Using `parentValue` is the equivalent of using [can-reflect] to get the value:
 
 ```js
 import canReflect from "can-reflect";

--- a/doc/start.md
+++ b/doc/start.md
@@ -5,10 +5,26 @@ values depending on their current state and the options provided to the binding
 when initialized.
 @signature `binding.start()`
 
-@body
-
 This method turns on both the child and parent observable listeners by calling
 [can-bind.prototype.startChild] and [can-bind.prototype.startParent].
+
+```js
+import Bind from "can-bind";
+import DefineMap from "can-define/map/map";
+import value from "can-value";
+
+const childMap = new DefineMap({childProp: "child value"});
+const parentMap = new DefineMap({parentProp: "parent value"});
+
+// Create the binding
+const binding = new Bind({
+  child: value.bind(childMap, "childProp"),
+  parent: value.bind(parentMap, "parentProp")
+});
+
+// Turn on the binding
+binding.start();
+```
 
 Additionally, it tries to sync the values of the child and parent observables,
 depending on:
@@ -17,29 +33,33 @@ depending on:
 2. The values of the `onInitDoNotUpdateChild` and `onInitSetUndefinedParentIfChildIsDefined` options.
 3. If it’s a one-way or two-way binding.
 
+@body
+
+## How initialization works
+
 By default, the initialization works as diagrammed below
 (with `onInitDoNotUpdateChild=false` and `onInitSetUndefinedParentIfChildIsDefined=true`):
 
 ```
 Child start value      Parent start value     Child end value  Parent end value  API call
 
-child=1           <->  parent=2           =>  child=2          parent=2          updateChild(2)
-child=1           <->  parent=undefined   =>  child=1          parent=1          updateParent(1)
-child=undefined   <->  parent=2           =>  child=2          parent=2          updateChild(2)
-child=undefined   <->  parent=undefined   =>  child=undefined  parent=undefined  updateChild(undefined)
-child=3           <->  parent=3           =>  child=3          parent=3          updateChild(3)
+child=1           <->  parent=2           =>  child=2          parent=2          _updateChild(2)
+child=1           <->  parent=undefined   =>  child=1          parent=1          _updateParent(1)
+child=undefined   <->  parent=2           =>  child=2          parent=2          _updateChild(2)
+child=undefined   <->  parent=undefined   =>  child=undefined  parent=undefined  _updateChild(undefined)
+child=3           <->  parent=3           =>  child=3          parent=3          _updateChild(3)
 
-child=1            ->  parent=2           =>  child=1          parent=1          updateParent(1)
-child=1            ->  parent=undefined   =>  child=1          parent=1          updateParent(1)
-child=undefined    ->  parent=2           =>  child=undefined  parent=undefined  updateParent(undefined)
-child=undefined    ->  parent=undefined   =>  child=undefined  parent=undefined  updateParent(undefined)
-child=3            ->  parent=3           =>  child=3          parent=3          updateParent(3)
+child=1            ->  parent=2           =>  child=1          parent=1          _updateParent(1)
+child=1            ->  parent=undefined   =>  child=1          parent=1          _updateParent(1)
+child=undefined    ->  parent=2           =>  child=undefined  parent=undefined  _updateParent(undefined)
+child=undefined    ->  parent=undefined   =>  child=undefined  parent=undefined  _updateParent(undefined)
+child=3            ->  parent=3           =>  child=3          parent=3          _updateParent(3)
 
-child=1           <-   parent=2           =>  child=2          parent=2          updateChild(2)
-child=1           <-   parent=undefined   =>  child=undefined  parent=undefined  updateChild(undefined)
-child=undefined   <-   parent=2           =>  child=2          parent=2          updateChild(2)
-child=undefined   <-   parent=undefined   =>  child=undefined  parent=undefined  updateChild(undefined)
-child=3           <-   parent=3           =>  child=3          parent=3          updateChild(3)
+child=1           <-   parent=2           =>  child=2          parent=2          _updateChild(2)
+child=1           <-   parent=undefined   =>  child=undefined  parent=undefined  _updateChild(undefined)
+child=undefined   <-   parent=2           =>  child=2          parent=2          _updateChild(2)
+child=undefined   <-   parent=undefined   =>  child=undefined  parent=undefined  _updateChild(undefined)
+child=3           <-   parent=3           =>  child=3          parent=3          _updateChild(3)
 ```
 
 To summarize the diagram above: by default, one-way bindings initialize however
@@ -65,7 +85,7 @@ Below is the same diagram as above, except with the options
 Δ Child start value     Parent start value     Child end value  Parent end value  API call
 
 Δ child=1           <-> parent=2           =>  child=1          parent=2          None
-  child=1           <-> parent=undefined   =>  child=1          parent=1          updateParent(1)
+  child=1           <-> parent=undefined   =>  child=1          parent=1          _updateParent(1)
 Δ child=undefined   <-> parent=2           =>  child=undefined  parent=2          None
 Δ child=undefined   <-> parent=undefined   =>  child=undefined  parent=undefined  None
 Δ child=3           <-> parent=3           =>  child=3          parent=3          None

--- a/doc/startChild.md
+++ b/doc/startChild.md
@@ -3,8 +3,25 @@
 @description Start listening to the child observable.
 @signature `binding.startChild()`
 
-@body
-
 This method checks whether the binding should listen to the child; if it should
-and it hasn’t already started listening, it will start listening in the `queue`
+and it hasn’t already started listening, then it will start listening to the
+`child` and update the `parent` in the `queue`
 provided when the binding was initialized.
+
+```js
+import Bind from "can-bind";
+import DefineMap from "can-define/map/map";
+import value from "can-value";
+
+const childMap = new DefineMap({childProp: "child value"});
+const parentMap = new DefineMap({parentProp: "parent value"});
+
+// Create the binding
+const binding = new Bind({
+  child: value.bind(childMap, "childProp"),
+  parent: value.bind(parentMap, "parentProp")
+});
+
+// Turn on just the child listener
+binding.startChild();
+```

--- a/doc/startParent.md
+++ b/doc/startParent.md
@@ -3,8 +3,25 @@
 @description Start listening to the parent observable.
 @signature `binding.startParent()`
 
-@body
-
 This method checks whether the binding should listen to the parent; if it should
-and it hasn’t already started listening, it will start listening in the `queue`
+and it hasn’t already started listening, then it will start listening to the
+`parent` and update the `child` in the `queue`
 provided when the binding was initialized.
+
+```js
+import Bind from "can-bind";
+import DefineMap from "can-define/map/map";
+import value from "can-value";
+
+const childMap = new DefineMap({childProp: "child value"});
+const parentMap = new DefineMap({parentProp: "parent value"});
+
+// Create the binding
+const binding = new Bind({
+  child: value.bind(childMap, "childProp"),
+  parent: value.bind(parentMap, "parentProp")
+});
+
+// Turn on just the parent listener
+binding.startParent();
+```

--- a/doc/stop.md
+++ b/doc/stop.md
@@ -3,6 +3,27 @@
 @description Stop listening to the observables.
 @signature `binding.stop()`
 
-@body
-
 This method turns off both the child and parent observable listeners.
+
+```js
+import Bind from "can-bind";
+import DefineMap from "can-define/map/map";
+import value from "can-value";
+
+const childMap = new DefineMap({childProp: "child value"});
+const parentMap = new DefineMap({parentProp: "parent value"});
+
+// Create the binding
+const binding = new Bind({
+  child: value.bind(childMap, "childProp"),
+  parent: value.bind(parentMap, "parentProp")
+});
+
+// Turn on the binding
+binding.start();
+
+// ... some other code
+
+// Turn off the binding
+binding.stop();
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-bind",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Updates one observable value with the value of another observable.",
   "homepage": "https://canjs.com/doc/can-bind.html",
   "repository": {

--- a/test/core.js
+++ b/test/core.js
@@ -319,8 +319,8 @@ canTestHelpers.dev.devOnlyTest("updateChildName and updateParentName options", f
 		updateParentName: "custom parent name"
 	});
 
-	assert.equal(binding.updateChild.name, "custom child name", "child name is correct");
-	assert.equal(binding.updateParent.name, "custom parent name", "parent name is correct");
+	assert.equal(binding._updateChild.name, "custom child name", "child name is correct");
+	assert.equal(binding._updateParent.name, "custom parent name", "parent name is correct");
 });
 
 QUnit.test("two-way binding with both values undefined", function(assert) {
@@ -355,7 +355,10 @@ QUnit.test("two-way binding updates are ignored after calling stop()", function(
 	});
 
 	// When the parent changes, turn the binding off
-	canReflect.onValue(parent, binding.stop, "domUI");
+	var turnOffBinding = function() {
+		binding.stop();
+	};
+	canReflect.onValue(parent, turnOffBinding, "domUI");
 
 	// Turn on the listeners
 	binding.start();
@@ -369,7 +372,7 @@ QUnit.test("two-way binding updates are ignored after calling stop()", function(
 	assert.equal(canReflect.getValue(parent), undefined, "parent stays the same");
 
 	// Turn off the listener
-	canReflect.offValue(parent, binding.stop, "domUI");
+	canReflect.offValue(parent, turnOffBinding, "domUI");
 });
 
 QUnit.test("parentValue property", function(assert) {


### PR DESCRIPTION
[The docs are currently available on the 5.0 site](https://canjs.github.io/next/doc/can-bind.html).

- Don’t `.bind(this)` to start & stop
- Make `updateChild` & `updateParent` private (really, change them to `_updateChild` & `_updateParent`) and remove their public docs
- Call custom `setChild` with the new value and the child; similarly, call `setParent` with the child’s new value and the parent observable
- Add docs for how to use the `setChild` & `setParent` options
- Move the prototype doc bodies into their signatures & add examples
- Add clarification to the `startChild` and `startParent` docs that the observables are updated in the `queue` provided