### PR TITLE
More updates based on Justin’s feedback

### DIFF
--- a/doc/can-bind.md
+++ b/doc/can-bind.md
@@ -181,17 +181,17 @@ Here’s an example that’s similar to what [can-route] does to bind a page’s
 
 ```js
 import Bind from "can-bind";
+import DefineMap from "can-define/map/map";
 import deparam from "can-deparam";
 import Observation from "can-observation";
 import param from "can-param";
-import SimpleMap from "can-simple-map";
 import SimpleObservable from "can-simple-observable";
 
 // The parent will be a string
-const parent = new SimpleObservable(undefined);
+const parent = new SimpleObservable("prop=value");
 
 // The child will be an object
-const map = new SimpleMap({ prop: "value" });
+const map = new DefineMap({});
 const child = new Observation(function() { return map.serialize(); });
 
 // Set up the binding
@@ -200,7 +200,7 @@ const binding = new Bind({
   parent: parent,
   setChild: function(newValue) {
     const objectValue = deparam(newValue);
-    map.set(objectValue);
+    map.update(objectValue);
   },
   setParent: function(newValue) {
     const stringValue = param(newValue);

--- a/doc/parentValue.md
+++ b/doc/parentValue.md
@@ -3,6 +3,9 @@
 @description Returns the parent’s value.
 @signature `binding.parentValue`
 
+The example below shows creating a new binding and then reading the parent’s
+value with `parentValue`:
+
 ```js
 import Bind from "can-bind";
 import DefineMap from "can-define/map/map";
@@ -29,3 +32,6 @@ import canReflect from "can-reflect";
 
 const parentValue = canReflect.getValue(parent);
 ```
+
+The `parentValue` property is most commonly used with
+[can-bind.prototype.startParent]; see its documentation for more details.

--- a/doc/startParent.md
+++ b/doc/startParent.md
@@ -8,20 +8,42 @@ and it hasn’t already started listening, then it will start listening to the
 `parent` and update the `child` in the `queue`
 provided when the binding was initialized.
 
+Usually you would want to [can-bind.prototype.start] the `child` and `parent`
+listeners at the same time, but calling `startParent` first and then calling
+[can-bind.prototype.start] later is useful when the child value hasn’t been
+initialized, as is the case with [can-stache-bindings] where we create the
+binding, read the [can-bind.prototype.parentValue], then create the child with
+all of the parent values.
+
+The example below shows a hypothetical scenario (with a
+[hypothetical API, `can-value.returnedBy`](https://github.com/canjs/can-value/issues/5))
+in which the child’s value isn’t really created until after `startParent` has
+been called:
+
 ```js
 import Bind from "can-bind";
 import DefineMap from "can-define/map/map";
 import value from "can-value";
 
-const childMap = new DefineMap({childProp: "child value"});
+let childMap;// Will be set later
 const parentMap = new DefineMap({parentProp: "parent value"});
 
 // Create the binding
 const binding = new Bind({
-  child: value.bind(childMap, "childProp"),
+  child: value.returnedBy(function() {
+    return childMap.childProp;
+  }),
   parent: value.bind(parentMap, "parentProp")
 });
 
 // Turn on just the parent listener
 binding.startParent();
+
+// Now we can get the parent’s value to create the child
+childMap = new DefineMap({
+  childProp: binding.parentValue
+});
+
+// Now turn on the child listener
+binding.start();
 ```


### PR DESCRIPTION
- Use DefineMap instead of SimpleMap in the setChild/setParent example
- Add an introductory sentence to the parentValue docs
- Add more info about why startParent is useful