### PR TITLE
Warn when the child side doesn't have the parent value when starting a sticky two-way binding

### DIFF
--- a/can-bind.js
+++ b/can-bind.js
@@ -384,15 +384,19 @@ canAssign(Bind.prototype, {
 			if(process.env.NODE_ENV !== 'production'){
 				// Here we want to do a dev-mode check to see whether the child does type conversions on
 				//  any two-way bindings.  This will be ignored and the child and parent will be desynched.
+				var parentContext = options.parent.observation && options.parent.observation.func || options.parent;
 				var childContext = options.child.observation && options.child.observation.func || options.child;
 				parentValue = canReflect.getValue(options.parent);
 				childValue = canReflect.getValue(options.child);
-				if (parentValue != null && childValue !== parentValue) {
+				if (options.sticky && childValue !== parentValue) {
 					canLog.warn(
-						"can-bind: The child of the sticky two-way binding " +
-						canReflect.getName(childContext) +
-						" is changing or converting its value when set. " +
-						"Conversions should only be done on the binding parent to preserve synchronization. " +
+						"can-bind: The " +
+						(options.sticky === "parentSticksToChild" ? "parent" : "child") +
+						" of the sticky two-way binding " +
+						(options.shortName || (canReflect.getName(parentContext) + "<->" + canReflect.getName(childContext))) +
+						" is changing or converting its value when set. Conversions should only be done on the binding " +
+						(options.sticky === "parentSticksToChild" ? "child" : "parent") +
+						" to preserve synchronization. " +
 						"See https://canjs.com/doc/can-stache-bindings.html#StickyBindings for more about sticky bindings"
 					);
 				}

--- a/can-bind.js
+++ b/can-bind.js
@@ -393,7 +393,7 @@ canAssign(Bind.prototype, {
 						"can-bind: The " +
 						(options.sticky === "parentSticksToChild" ? "parent" : "child") +
 						" of the sticky two-way binding " +
-						(options.shortName || (canReflect.getName(parentContext) + "<->" + canReflect.getName(childContext))) +
+						(options.debugName || (canReflect.getName(parentContext) + "<->" + canReflect.getName(childContext))) +
 						" is changing or converting its value when set. Conversions should only be done on the binding " +
 						(options.sticky === "parentSticksToChild" ? "child" : "parent") +
 						" to preserve synchronization. " +

--- a/can-bind.js
+++ b/can-bind.js
@@ -380,6 +380,25 @@ canAssign(Bind.prototype, {
 				}
 			}
 
+			//!steal-remove-start
+			if(process.env.NODE_ENV !== 'production'){
+				// Here we want to do a dev-mode check to see whether the child does type conversions on
+				//  any two-way bindings.  This will be ignored and the child and parent will be desynched.
+				var childContext = options.child.observation && options.child.observation.func || options.child;
+				parentValue = canReflect.getValue(options.parent);
+				childValue = canReflect.getValue(options.child);
+				if (parentValue != null && childValue !== parentValue) {
+					canLog.warn(
+						"can-bind: The child of the sticky two-way binding " +
+						canReflect.getName(childContext) +
+						" is changing or converting its value when set. " +
+						"Conversions should only be done on the binding parent to preserve synchronization. " +
+						"See https://canjs.com/doc/can-stache-bindings.html#StickyBindings for more about sticky bindings"
+					);
+				}
+			}
+			//!steal-remove-end
+
 		} else if (this._childToParent === true) {
 			// One-way child -> parent, so update the parent
 			// Check if we are to initialize the parent

--- a/test/cycles-and-sticky.js
+++ b/test/cycles-and-sticky.js
@@ -243,3 +243,32 @@ QUnit.test("two-way binding - 0 cycles childSticksToParent", function(assert) {
 
 	}, assert);
 });
+
+canTestHelpers.dev.devOnlyTest("warn when changing the value of a sticky binding child-side", function(assert) {
+	assert.expect(4);
+	var teardown = canTestHelpers.dev.willWarn(
+		"can-bind: The child of the sticky two-way binding Test Child Observable is changing or converting its value when set. " +
+			"Conversions should only be done on the binding parent to preserve synchronization. " +
+			"See https://canjs.com/doc/can-stache-bindings.html#StickyBindings for more about sticky bindings",
+		function(text, match) {
+			if(match) {
+				assert.ok(true, "Correct warning generated");
+			}
+		}
+	);
+
+	var parent = new SimpleObservable(1);
+	var child = new SettableObservable(helpers.protectAgainstInfiniteLoops(function() { return 0; }), 0);
+	canReflect.setName(child.observation.func, "Test Child Observable");
+
+	cycleStickyTest({
+		parent: parent,
+		child: child,
+		startBySetting: "parent",
+		sticky: "childSticksToParent",
+		expectedParent: 1,
+		expectedChild: 0
+	}, assert);
+
+	assert.equal(teardown(), 1, "Warning generated only once");
+});

--- a/test/cycles-and-sticky.js
+++ b/test/cycles-and-sticky.js
@@ -50,7 +50,7 @@ function cycleStickyTest(options, assert) {
 	var expectedParent = options.expectedParent;
 	var parent = options.parent;
 	var sticky = options.sticky;
-	var shortName = options.shortName;
+	var debugName = options.debugName;
 
 	// Create the binding
 	var binding = new Bind({
@@ -59,7 +59,7 @@ function cycleStickyTest(options, assert) {
 		onInitDoNotUpdateChild: true,
 		parent: parent,
 		sticky: sticky,
-		shortName: shortName
+		debugName: debugName
 	});
 
 	// Turn on the listeners
@@ -293,7 +293,7 @@ canTestHelpers.dev.devOnlyTest("warn when changing the value of a sticky binding
 		sticky: "childSticksToParent",
 		expectedParent: 1,
 		expectedChild: 0,
-		shortName: shortName
+		debugName: shortName
 	}, assert);
 
 	assert.equal(teardown(), 1, "Warning generated only once");

--- a/test/cycles-and-sticky.js
+++ b/test/cycles-and-sticky.js
@@ -50,6 +50,7 @@ function cycleStickyTest(options, assert) {
 	var expectedParent = options.expectedParent;
 	var parent = options.parent;
 	var sticky = options.sticky;
+	var shortName = options.shortName;
 
 	// Create the binding
 	var binding = new Bind({
@@ -57,7 +58,8 @@ function cycleStickyTest(options, assert) {
 		cycles: cycles,
 		onInitDoNotUpdateChild: true,
 		parent: parent,
-		sticky: sticky
+		sticky: sticky,
+		shortName: shortName
 	});
 
 	// Turn on the listeners
@@ -245,9 +247,9 @@ QUnit.test("two-way binding - 0 cycles childSticksToParent", function(assert) {
 });
 
 canTestHelpers.dev.devOnlyTest("warn when changing the value of a sticky binding child-side", function(assert) {
-	assert.expect(4);
+	assert.expect(8);
 	var teardown = canTestHelpers.dev.willWarn(
-		"can-bind: The child of the sticky two-way binding Test Child Observable is changing or converting its value when set. " +
+		"can-bind: The child of the sticky two-way binding SimpleObservable<1><->Test Child Observable is changing or converting its value when set. " +
 			"Conversions should only be done on the binding parent to preserve synchronization. " +
 			"See https://canjs.com/doc/can-stache-bindings.html#StickyBindings for more about sticky bindings",
 		function(text, match) {
@@ -268,6 +270,30 @@ canTestHelpers.dev.devOnlyTest("warn when changing the value of a sticky binding
 		sticky: "childSticksToParent",
 		expectedParent: 1,
 		expectedChild: 0
+	}, assert);
+
+	assert.equal(teardown(), 1, "Warning generated only once");
+
+	// also test with a short name given to the binding
+	var shortName = "The test binding";
+	teardown = canTestHelpers.dev.willWarn(
+		"can-bind: The child of the sticky two-way binding The test binding is changing or converting its value when set. " +
+			"Conversions should only be done on the binding parent to preserve synchronization. " +
+			"See https://canjs.com/doc/can-stache-bindings.html#StickyBindings for more about sticky bindings",
+		function(text, match) {
+			if(match) {
+				assert.ok(true, "Correct warning generated");
+			}
+		}
+	);
+	cycleStickyTest({
+		parent: parent,
+		child: child,
+		startBySetting: "parent",
+		sticky: "childSticksToParent",
+		expectedParent: 1,
+		expectedChild: 0,
+		shortName: shortName
 	}, assert);
 
 	assert.equal(teardown(), 1, "Warning generated only once");


### PR DESCRIPTION
Pushing down https://github.com/canjs/can-stache-bindings/pull/535 for https://github.com/canjs/can-stache-bindings/issues/487 into can-bind, will update the aforementioned PR to use this when released.