### PR TITLE
Fix: Issue #24 Test asserting canReflect.getName fails in IE11

### DIFF
--- a/test/cycles-and-sticky.js
+++ b/test/cycles-and-sticky.js
@@ -248,11 +248,9 @@ QUnit.test("two-way binding - 0 cycles childSticksToParent", function(assert) {
 
 canTestHelpers.dev.devOnlyTest("warn when changing the value of a sticky binding child-side", function(assert) {
 	assert.expect(8);
-	var teardown = canTestHelpers.dev.willWarn(
-		"can-bind: The child of the sticky two-way binding SimpleObservable<1><->Test Child Observable is changing or converting its value when set. " +
-			"Conversions should only be done on the binding parent to preserve synchronization. " +
-			"See https://canjs.com/doc/can-stache-bindings.html#StickyBindings for more about sticky bindings",
-		function(text, match) {
+	var msg = /.* changing or converting its value when set.*/;
+
+	var teardown = canTestHelpers.dev.willWarn(msg, function(text, match) {
 			if(match) {
 				assert.ok(true, "Correct warning generated");
 			}
@@ -276,11 +274,7 @@ canTestHelpers.dev.devOnlyTest("warn when changing the value of a sticky binding
 
 	// also test with a short name given to the binding
 	var shortName = "The test binding";
-	teardown = canTestHelpers.dev.willWarn(
-		"can-bind: The child of the sticky two-way binding The test binding is changing or converting its value when set. " +
-			"Conversions should only be done on the binding parent to preserve synchronization. " +
-			"See https://canjs.com/doc/can-stache-bindings.html#StickyBindings for more about sticky bindings",
-		function(text, match) {
+	teardown = canTestHelpers.dev.willWarn(msg, function(text, match) {
 			if(match) {
 				assert.ok(true, "Correct warning generated");
 			}

--- a/test/test.html
+++ b/test/test.html
@@ -1,4 +1,4 @@
 <!doctype html>
 <title>can-bind tests</title>
-<script src="../node_modules/steal/steal-with-promises.js" main="can-bind/test/test"></script>
+<script src="../node_modules/steal/steal.js" main="can-bind/test/test"></script>
 <div id="qunit-fixture"></div>

--- a/test/test.html
+++ b/test/test.html
@@ -1,4 +1,4 @@
 <!doctype html>
 <title>can-bind tests</title>
-<script src="../node_modules/steal/steal.js" main="can-bind/test/test"></script>
+<script src="../node_modules/steal/steal-with-promises.js" main="can-bind/test/test"></script>
 <div id="qunit-fixture"></div>


### PR DESCRIPTION
Fixed using RegEx for [Issue #24](https://github.com/canjs/can-bind/issues/24)